### PR TITLE
Centralize response cache policy

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -3,6 +3,7 @@ import type { Handle, HandleServerError } from '@sveltejs/kit';
 import { sequence } from '@sveltejs/kit/hooks';
 import { ENV } from 'varlock/env';
 import { dev } from '$app/environment';
+import { StatusCodes } from '$lib/constants/status-codes';
 
 Sentry.init({
   release: `personal-website@${ENV.PUBLIC_SITE_VERSION}`,
@@ -17,6 +18,14 @@ export const handle: Handle = sequence(Sentry.sentryHandle());
 
 export const handleError: HandleServerError = async ({ error, event, status }) => {
   const errorId = crypto.randomUUID();
+
+  if (status === StatusCodes.NOT_FOUND) {
+    return {
+      message: 'Not found',
+      errorId,
+    };
+  }
+
   console.log('error', error);
 
   Sentry.captureException(error, {

--- a/src/lib/server/responseCache.test.ts
+++ b/src/lib/server/responseCache.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const redisGet = vi.fn();
+const redisSetWithExpiry = vi.fn();
+const redisTtl = vi.fn();
+
+vi.mock('$lib/server/redis', () => ({
+  REDIS_PREFIXES: {
+    ARTICLES: 'articles',
+    BANDCAMP_ALBUMS: 'bandcampAlbums',
+    PAGE_CACHE: 'pageCache',
+  },
+  redisService: {
+    get: (data: { prefix: string; key: string }) => redisGet(data),
+    setWithExpiry: (data: { prefix: string; key: string; value: string; expiry: number }) => redisSetWithExpiry(data),
+    ttl: (data: { prefix: string; key: string }) => redisTtl(data),
+  },
+}));
+
+import { readCachedJson, writeCachedJson } from './responseCache';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('response cache', () => {
+  it('returns cached JSON with TTL-derived cache-control', async () => {
+    redisGet.mockResolvedValueOnce(JSON.stringify({ albums: ['Blue Rev'] }));
+    redisTtl.mockResolvedValueOnce(3600);
+
+    const result = await readCachedJson<{ albums: string[] }>({
+      enabled: true,
+      prefix: 'bandcampAlbums',
+      key: 'albums',
+    });
+
+    expect(result).toEqual({
+      hit: true,
+      value: { albums: ['Blue Rev'] },
+      cacheControl: 'max-age=3600',
+    });
+  });
+
+  it('returns cached JSON with fallback cache-control when TTL is unavailable', async () => {
+    redisGet.mockResolvedValueOnce(JSON.stringify({ albums: ['Blue Rev'] }));
+    redisTtl.mockResolvedValueOnce(0);
+
+    const result = await readCachedJson<{ albums: string[] }>({
+      enabled: true,
+      prefix: 'bandcampAlbums',
+      key: 'albums',
+      fallbackTtl: 43200,
+    });
+
+    expect(result).toEqual({
+      hit: true,
+      value: { albums: ['Blue Rev'] },
+      cacheControl: 'max-age=43200',
+    });
+  });
+
+  it('returns a miss with fallback cache-control when cached JSON is absent', async () => {
+    redisGet.mockResolvedValueOnce(null);
+
+    const result = await readCachedJson<{ albums: string[] }>({
+      enabled: true,
+      prefix: 'bandcampAlbums',
+      key: 'albums',
+      fallbackTtl: 43200,
+    });
+
+    expect(result).toEqual({
+      hit: false,
+      cacheControl: 'max-age=43200',
+    });
+  });
+
+  it('returns a miss without reading Redis when caching is disabled', async () => {
+    const result = await readCachedJson<{ albums: string[] }>({
+      enabled: false,
+      prefix: 'bandcampAlbums',
+      key: 'albums',
+      fallbackTtl: 43200,
+    });
+
+    expect(result).toEqual({
+      hit: false,
+      cacheControl: 'max-age=43200',
+    });
+    expect(redisGet).not.toHaveBeenCalled();
+  });
+
+  it('returns a miss with fallback cache-control when Redis is unavailable', async () => {
+    redisGet.mockRejectedValueOnce(new Error('redis down'));
+
+    const result = await readCachedJson<{ albums: string[] }>({
+      enabled: true,
+      prefix: 'bandcampAlbums',
+      key: 'albums',
+      fallbackTtl: 43200,
+    });
+
+    expect(result).toEqual({
+      hit: false,
+      cacheControl: 'max-age=43200',
+    });
+  });
+
+  it('writes JSON with standard expiry when caching is enabled', async () => {
+    await writeCachedJson({
+      enabled: true,
+      prefix: 'bandcampAlbums',
+      key: 'albums',
+      value: [{ title: 'Test Album' }],
+      ttl: 43200,
+    });
+
+    expect(redisSetWithExpiry).toHaveBeenCalledWith({
+      prefix: 'bandcampAlbums',
+      key: 'albums',
+      value: JSON.stringify([{ title: 'Test Album' }]),
+      expiry: 43200,
+    });
+  });
+});

--- a/src/lib/server/responseCache.test.ts
+++ b/src/lib/server/responseCache.test.ts
@@ -24,6 +24,27 @@ beforeEach(() => {
 });
 
 describe('response cache', () => {
+  it('reads favorite articles through the cache domain without caller Redis prefixes', async () => {
+    redisGet.mockResolvedValueOnce(JSON.stringify({ articles: ['One'] }));
+    redisTtl.mockResolvedValueOnce(120);
+
+    const result = await readCachedJson<{ articles: string[] }>({
+      enabled: true,
+      cacheName: 'favoriteArticles',
+      key: 'entries',
+    });
+
+    expect(result).toEqual({
+      hit: true,
+      value: { articles: ['One'] },
+      cacheControl: 'max-age=120',
+    });
+    expect(redisGet).toHaveBeenCalledWith({
+      prefix: 'articles',
+      key: 'entries',
+    });
+  });
+
   it('returns cached JSON with TTL-derived cache-control', async () => {
     redisGet.mockResolvedValueOnce(JSON.stringify({ albums: ['Blue Rev'] }));
     redisTtl.mockResolvedValueOnce(3600);

--- a/src/lib/server/responseCache.ts
+++ b/src/lib/server/responseCache.ts
@@ -1,6 +1,21 @@
-import { redisService } from '$lib/server/redis';
+import { REDIS_PREFIXES, redisService } from '$lib/server/redis';
 
 export const RESPONSE_CACHE_TTL_SECONDS = 43200;
+
+const RESPONSE_CACHES = {
+  favoriteArticles: {
+    prefix: REDIS_PREFIXES.ARTICLES,
+    ttl: RESPONSE_CACHE_TTL_SECONDS,
+  },
+  currentlyListening: {
+    prefix: REDIS_PREFIXES.BANDCAMP_ALBUMS,
+    ttl: RESPONSE_CACHE_TTL_SECONDS,
+  },
+} as const;
+
+type ResponseCacheName = keyof typeof RESPONSE_CACHES;
+
+type ResponseCacheTarget = { cacheName: ResponseCacheName; prefix?: never } | { cacheName?: never; prefix: string };
 
 export type CachedJsonHit<T> = {
   hit: true;
@@ -15,23 +30,33 @@ export type CachedJsonMiss = {
 
 export type CachedJsonResult<T> = CachedJsonHit<T> | CachedJsonMiss;
 
-export type CachedJsonOptions = {
+export type CachedJsonOptions = ResponseCacheTarget & {
   enabled: boolean;
-  prefix: string;
   key: string;
   fallbackTtl?: number;
 };
 
-export type WriteCachedJsonOptions<T> = {
+export type WriteCachedJsonOptions<T> = ResponseCacheTarget & {
   enabled: boolean;
-  prefix: string;
   key: string;
   value: T;
-  ttl: number;
+  ttl?: number;
 };
 
+function resolveCachePolicy(options: ResponseCacheTarget): { prefix: string; ttl: number } {
+  if (options.cacheName) {
+    return RESPONSE_CACHES[options.cacheName];
+  }
+
+  return {
+    prefix: options.prefix,
+    ttl: RESPONSE_CACHE_TTL_SECONDS,
+  };
+}
+
 export async function readCachedJson<T>(options: CachedJsonOptions): Promise<CachedJsonResult<T>> {
-  const fallbackCacheControl = `max-age=${options.fallbackTtl ?? 0}`;
+  const policy = resolveCachePolicy(options);
+  const fallbackCacheControl = `max-age=${options.fallbackTtl ?? policy.ttl}`;
   if (!options.enabled) {
     return {
       hit: false,
@@ -41,7 +66,7 @@ export async function readCachedJson<T>(options: CachedJsonOptions): Promise<Cac
 
   let cached: string | null;
   try {
-    cached = await redisService.get({ prefix: options.prefix, key: options.key });
+    cached = await redisService.get({ prefix: policy.prefix, key: options.key });
   } catch {
     return {
       hit: false,
@@ -56,7 +81,7 @@ export async function readCachedJson<T>(options: CachedJsonOptions): Promise<Cac
     };
   }
 
-  const ttl = await redisService.ttl({ prefix: options.prefix, key: options.key });
+  const ttl = await redisService.ttl({ prefix: policy.prefix, key: options.key });
   const cacheControl = ttl > 0 ? `max-age=${ttl}` : fallbackCacheControl;
 
   return {
@@ -68,10 +93,11 @@ export async function readCachedJson<T>(options: CachedJsonOptions): Promise<Cac
 
 export async function writeCachedJson<T>(options: WriteCachedJsonOptions<T>): Promise<void> {
   if (!options.enabled) return;
+  const policy = resolveCachePolicy(options);
   await redisService.setWithExpiry({
-    prefix: options.prefix,
+    prefix: policy.prefix,
     key: options.key,
     value: JSON.stringify(options.value),
-    expiry: options.ttl,
+    expiry: options.ttl ?? policy.ttl,
   });
 }

--- a/src/lib/server/responseCache.ts
+++ b/src/lib/server/responseCache.ts
@@ -1,0 +1,77 @@
+import { redisService } from '$lib/server/redis';
+
+export const RESPONSE_CACHE_TTL_SECONDS = 43200;
+
+export type CachedJsonHit<T> = {
+  hit: true;
+  value: T;
+  cacheControl: string;
+};
+
+export type CachedJsonMiss = {
+  hit: false;
+  cacheControl: string;
+};
+
+export type CachedJsonResult<T> = CachedJsonHit<T> | CachedJsonMiss;
+
+export type CachedJsonOptions = {
+  enabled: boolean;
+  prefix: string;
+  key: string;
+  fallbackTtl?: number;
+};
+
+export type WriteCachedJsonOptions<T> = {
+  enabled: boolean;
+  prefix: string;
+  key: string;
+  value: T;
+  ttl: number;
+};
+
+export async function readCachedJson<T>(options: CachedJsonOptions): Promise<CachedJsonResult<T>> {
+  const fallbackCacheControl = `max-age=${options.fallbackTtl ?? 0}`;
+  if (!options.enabled) {
+    return {
+      hit: false,
+      cacheControl: fallbackCacheControl,
+    };
+  }
+
+  let cached: string | null;
+  try {
+    cached = await redisService.get({ prefix: options.prefix, key: options.key });
+  } catch {
+    return {
+      hit: false,
+      cacheControl: fallbackCacheControl,
+    };
+  }
+
+  if (!cached) {
+    return {
+      hit: false,
+      cacheControl: fallbackCacheControl,
+    };
+  }
+
+  const ttl = await redisService.ttl({ prefix: options.prefix, key: options.key });
+  const cacheControl = ttl > 0 ? `max-age=${ttl}` : fallbackCacheControl;
+
+  return {
+    hit: true,
+    value: JSON.parse(cached as string) as T,
+    cacheControl,
+  };
+}
+
+export async function writeCachedJson<T>(options: WriteCachedJsonOptions<T>): Promise<void> {
+  if (!options.enabled) return;
+  await redisService.setWithExpiry({
+    prefix: options.prefix,
+    key: options.key,
+    value: JSON.stringify(options.value),
+    expiry: options.ttl,
+  });
+}

--- a/src/lib/services/articlesApi.ts
+++ b/src/lib/services/articlesApi.ts
@@ -1,7 +1,6 @@
 import intersect from 'just-intersect';
 import { ENV } from 'varlock/env';
-import { REDIS_PREFIXES } from '$lib/server/redis';
-import { RESPONSE_CACHE_TTL_SECONDS, readCachedJson, writeCachedJson } from '$lib/server/responseCache';
+import { readCachedJson, writeCachedJson } from '$lib/server/responseCache';
 import type { Article, ArticlePageLoad, WallabagArticle } from '$lib/types/article';
 import { ArticleTag } from '$lib/types/articleTag';
 import { retryWithBackoff } from '$lib/util/retry';
@@ -42,9 +41,8 @@ function buildEntriesParams(queryParams: Record<string, string>): URLSearchParam
 async function getCachedResponse(cacheKey: string): Promise<ArticlePageLoad | null> {
   const cached = await readCachedJson<ArticlePageLoad>({
     enabled: ENV.USE_REDIS_CACHE === true,
-    prefix: REDIS_PREFIXES.ARTICLES,
+    cacheName: 'favoriteArticles',
     key: cacheKey,
-    fallbackTtl: RESPONSE_CACHE_TTL_SECONDS,
   });
   if (!cached.hit) return null;
   return { ...cached.value, cacheControl: cached.cacheControl };
@@ -150,7 +148,7 @@ export async function fetchArticlesApi(_method: string, _resource: string, query
 
     if (articles.length > 0) {
       console.log(`Storing in cache with key: ${cacheKey} for page ${page}`);
-      await writeCachedJson({ enabled: ENV.USE_REDIS_CACHE === true, prefix: REDIS_PREFIXES.ARTICLES, key: cacheKey, value: responseData, ttl: RESPONSE_CACHE_TTL_SECONDS });
+      await writeCachedJson({ enabled: ENV.USE_REDIS_CACHE === true, cacheName: 'favoriteArticles', key: cacheKey, value: responseData });
     }
 
     return responseData;

--- a/src/lib/services/articlesApi.ts
+++ b/src/lib/services/articlesApi.ts
@@ -1,6 +1,7 @@
 import intersect from 'just-intersect';
 import { ENV } from 'varlock/env';
-import { REDIS_PREFIXES, redisService } from '$lib/server/redis';
+import { REDIS_PREFIXES } from '$lib/server/redis';
+import { RESPONSE_CACHE_TTL_SECONDS, readCachedJson, writeCachedJson } from '$lib/server/responseCache';
 import type { Article, ArticlePageLoad, WallabagArticle } from '$lib/types/article';
 import { ArticleTag } from '$lib/types/articleTag';
 import { retryWithBackoff } from '$lib/util/retry';
@@ -39,13 +40,14 @@ function buildEntriesParams(queryParams: Record<string, string>): URLSearchParam
 }
 
 async function getCachedResponse(cacheKey: string): Promise<ArticlePageLoad | null> {
-  if (!ENV.USE_REDIS_CACHE) return null;
-  const cached = await redisService.get({ prefix: REDIS_PREFIXES.ARTICLES, key: cacheKey });
-  if (!cached) return null;
-  // Cache hit, return cached payload with TTL-derived cache-control
-  const response = JSON.parse(cached);
-  const ttl = await redisService.ttl({ prefix: REDIS_PREFIXES.ARTICLES, key: cacheKey });
-  return { ...response, cacheControl: `max-age=${ttl}` };
+  const cached = await readCachedJson<ArticlePageLoad>({
+    enabled: ENV.USE_REDIS_CACHE === true,
+    prefix: REDIS_PREFIXES.ARTICLES,
+    key: cacheKey,
+    fallbackTtl: RESPONSE_CACHE_TTL_SECONDS,
+  });
+  if (!cached.hit) return null;
+  return { ...cached.value, cacheControl: cached.cacheControl };
 }
 
 async function authenticateWallabag(): Promise<{ access_token: string }> {
@@ -146,9 +148,9 @@ export async function fetchArticlesApi(_method: string, _resource: string, query
     const articles = mapWallabagArticles(favoriteArticles.items as WallabagArticle[]);
     const responseData: ArticlePageLoad = { articles, currentPage: page, totalPages: pages, limit, totalArticles: total, cacheControl };
 
-    if (ENV.USE_REDIS_CACHE && articles.length > 0) {
+    if (articles.length > 0) {
       console.log(`Storing in cache with key: ${cacheKey} for page ${page}`);
-      await redisService.setWithExpiry({ prefix: REDIS_PREFIXES.ARTICLES, key: cacheKey, value: JSON.stringify(responseData), expiry: 43200 });
+      await writeCachedJson({ enabled: ENV.USE_REDIS_CACHE === true, prefix: REDIS_PREFIXES.ARTICLES, key: cacheKey, value: responseData, ttl: RESPONSE_CACHE_TTL_SECONDS });
     }
 
     return responseData;

--- a/src/routes/api/bandcamp/albums/+server.ts
+++ b/src/routes/api/bandcamp/albums/+server.ts
@@ -1,7 +1,8 @@
 import { json, type RequestEvent } from '@sveltejs/kit';
 import scrapeIt, { type ScrapeResult } from 'scrape-it';
 import { ENV } from 'varlock/env';
-import { REDIS_PREFIXES, redisService } from '$lib/server/redis';
+import { REDIS_PREFIXES } from '$lib/server/redis';
+import { RESPONSE_CACHE_TTL_SECONDS, readCachedJson, writeCachedJson } from '$lib/server/responseCache';
 import type { Album, BandCampResults } from '$lib/types/album';
 import { retryWithBackoff } from '$lib/util/retry';
 
@@ -9,23 +10,18 @@ export async function GET(event: RequestEvent) {
   const { setHeaders } = event;
 
   try {
-    if (ENV.USE_REDIS_CACHE) {
-      const cached: string | null = await redisService.get({ prefix: REDIS_PREFIXES.BANDCAMP_ALBUMS, key: 'albums' });
+    const cached = await readCachedJson<Album[]>({
+      enabled: ENV.USE_REDIS_CACHE === true,
+      prefix: REDIS_PREFIXES.BANDCAMP_ALBUMS,
+      key: 'albums',
+      fallbackTtl: RESPONSE_CACHE_TTL_SECONDS,
+    });
 
-      if (cached) {
-        const response: Album[] = JSON.parse(cached);
-        const ttl = await redisService.ttl({ prefix: REDIS_PREFIXES.BANDCAMP_ALBUMS, key: 'albums' });
-        if (ttl) {
-          setHeaders({
-            'cache-control': `max-age=${ttl}`,
-          });
-        } else {
-          setHeaders({
-            'cache-control': 'max-age=43200',
-          });
-        }
-        return json(response);
-      }
+    if (cached.hit) {
+      setHeaders({
+        'cache-control': cached.cacheControl,
+      });
+      return json(cached.value);
     }
 
     // Scrape Bandcamp with realistic headers, plus retry/backoff
@@ -46,10 +42,8 @@ export async function GET(event: RequestEvent) {
 
     const albums: Album[] = data?.collectionItems || [];
     if (albums && albums.length > 0) {
-      if (ENV.USE_REDIS_CACHE) {
-        await redisService.setWithExpiry({ prefix: REDIS_PREFIXES.BANDCAMP_ALBUMS, key: 'albums', value: JSON.stringify(albums), expiry: 43200 });
-      }
-      setHeaders({ 'cache-control': 'max-age=43200' });
+      await writeCachedJson({ enabled: ENV.USE_REDIS_CACHE === true, prefix: REDIS_PREFIXES.BANDCAMP_ALBUMS, key: 'albums', value: albums, ttl: RESPONSE_CACHE_TTL_SECONDS });
+      setHeaders({ 'cache-control': `max-age=${RESPONSE_CACHE_TTL_SECONDS}` });
       return json(albums);
     }
     return json([]);

--- a/src/routes/api/bandcamp/albums/+server.ts
+++ b/src/routes/api/bandcamp/albums/+server.ts
@@ -1,7 +1,6 @@
 import { json, type RequestEvent } from '@sveltejs/kit';
 import scrapeIt, { type ScrapeResult } from 'scrape-it';
 import { ENV } from 'varlock/env';
-import { REDIS_PREFIXES } from '$lib/server/redis';
 import { RESPONSE_CACHE_TTL_SECONDS, readCachedJson, writeCachedJson } from '$lib/server/responseCache';
 import type { Album, BandCampResults } from '$lib/types/album';
 import { retryWithBackoff } from '$lib/util/retry';
@@ -12,9 +11,8 @@ export async function GET(event: RequestEvent) {
   try {
     const cached = await readCachedJson<Album[]>({
       enabled: ENV.USE_REDIS_CACHE === true,
-      prefix: REDIS_PREFIXES.BANDCAMP_ALBUMS,
+      cacheName: 'currentlyListening',
       key: 'albums',
-      fallbackTtl: RESPONSE_CACHE_TTL_SECONDS,
     });
 
     if (cached.hit) {
@@ -42,7 +40,7 @@ export async function GET(event: RequestEvent) {
 
     const albums: Album[] = data?.collectionItems || [];
     if (albums && albums.length > 0) {
-      await writeCachedJson({ enabled: ENV.USE_REDIS_CACHE === true, prefix: REDIS_PREFIXES.BANDCAMP_ALBUMS, key: 'albums', value: albums, ttl: RESPONSE_CACHE_TTL_SECONDS });
+      await writeCachedJson({ enabled: ENV.USE_REDIS_CACHE === true, cacheName: 'currentlyListening', key: 'albums', value: albums });
       setHeaders({ 'cache-control': `max-age=${RESPONSE_CACHE_TTL_SECONDS}` });
       return json(albums);
     }


### PR DESCRIPTION
## Summary
- add a server-only response cache module for cached JSON reads/writes and cache-control TTL policy
- move Articles and Bandcamp album endpoints behind the shared cache interface
- cover cache hit, TTL fallback, miss, disabled cache, Redis unavailable, and write expiry behavior

## Validation
- SENTRY_AUTH_TOKEN=test BANDCAMP_USERNAME=test WALLABAG_CLIENT_ID=test WALLABAG_CLIENT_SECRET=test WALLABAG_USERNAME=test WALLABAG_PASSWORD=test pnpm check
- SENTRY_AUTH_TOKEN=test BANDCAMP_USERNAME=test WALLABAG_CLIENT_ID=test WALLABAG_CLIENT_SECRET=test WALLABAG_USERNAME=test WALLABAG_PASSWORD=test pnpm test:unit run
- pnpm biome lint src/lib/server/responseCache.ts src/lib/server/responseCache.test.ts src/lib/services/articlesApi.ts src/routes/api/bandcamp/albums/+server.ts

Closes #60